### PR TITLE
fix: Remove test app from `mod`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2024-05-15
+
+### Bug Fixes
+
+- Fix: remove test application from mod
+
+### Miscellaneous Tasks
+
+- Chore: update license to Apache2 (#76)
+- Chore: make sure slug is compatible with the latest spec
+
 ## [0.2.0] - 2023-12-04
 
 ### Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs:
 
 .PHONY: changelog
 changelog:
-	git cliff -o CHANGELOG.md
+	git cliff --bump -o CHANGELOG.md
 
 .PHONY: inngest-dev
 inngest-dev:

--- a/dev.exs
+++ b/dev.exs
@@ -1,0 +1,9 @@
+require Logger
+
+Task.async(fn ->
+  {:ok, _pid} = Inngest.Test.Application.start(:normal, [])
+  Logger.debug("Starting SDK development server")
+
+  Process.sleep(:infinity)
+end)
+|> Task.await(:infinity)

--- a/lib/inngest/function.ex
+++ b/lib/inngest/function.ex
@@ -91,8 +91,8 @@ defmodule Inngest.Function do
 
       @impl true
       def slug() do
-        fn_opts()
-        |> Map.get(:id)
+        fnid = fn_opts() |> Map.get(:id)
+        Inngest.Util.slugify(Config.app_name() <> "-" <> fnid)
       end
 
       @impl true

--- a/lib/inngest/util.ex
+++ b/lib/inngest/util.ex
@@ -27,4 +27,15 @@ defmodule Inngest.Util do
   def day_in_seconds(), do: 60 * 60 * 24
   def hour_in_seconds(), do: 60 * 60
   def minute_in_seconds(), do: 60
+
+  def slugify(text) when is_binary(text) do
+    text
+    |> String.downcase()
+    |> String.trim()
+    |> String.normalize(:nfd)
+    |> String.replace(~r/[^a-z0-9\s-]/u, "  ")
+    |> String.replace(~r/[\s-]+/, "-", global: true)
+  end
+
+  def slugify(_), do: ""
 end

--- a/mix.exs
+++ b/mix.exs
@@ -85,7 +85,6 @@ defmodule Inngest.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      mod: {Inngest.Test.Application, []},
       extra_applications: [:logger]
     ]
   end
@@ -119,7 +118,7 @@ defmodule Inngest.MixProject do
       "fmt:check": [
         "format --check-formatted mix.exs 'lib/**/*.{ex,exs}' 'test/**/*.{ex,exs}'"
       ],
-      dev: "run --no-halt"
+      dev: "run --no-halt dev.exs"
     ]
   end
 end

--- a/test/inngest/function/cases/failure_handler_test.exs
+++ b/test/inngest/function/cases/failure_handler_test.exs
@@ -27,7 +27,7 @@ defmodule Inngest.Function.Cases.RetriableTest do
 
     {:ok, %{"data" => events}} = DevServer.list_events()
 
-    assert %{"id" => failed_id} =
+    assert %{"internal_id" => failed_id} =
              events
              |> Enum.find(fn evt ->
                Map.get(evt, "name") == "inngest/function.failed" &&

--- a/test/inngest/function_test.exs
+++ b/test/inngest/function_test.exs
@@ -7,7 +7,7 @@ defmodule Inngest.FunctionTest do
 
   describe "slug/0" do
     test "return name of function as slug" do
-      assert "test-event" == TestEventFn.slug()
+      assert "inngestapp-test-event" == TestEventFn.slug()
     end
   end
 
@@ -31,7 +31,7 @@ defmodule Inngest.FunctionTest do
     test "event function should return approprivate map" do
       assert [
                %{
-                 id: "test-event",
+                 id: "inngestapp-test-event",
                  name: "App / Email: Awesome Event Func",
                  triggers: [
                    %Trigger{event: "my/awesome.event"}
@@ -56,7 +56,7 @@ defmodule Inngest.FunctionTest do
     test "cron function should return appropriate map" do
       assert [
                %{
-                 id: "test-cron",
+                 id: "inngestapp-test-cron",
                  name: "Awesome Cron Func",
                  triggers: [
                    %Trigger{cron: "TZ=America/Los_Angeles * * * * *"}

--- a/test/support/dev_server.ex
+++ b/test/support/dev_server.ex
@@ -49,6 +49,7 @@ defmodule Inngest.Test.DevServer do
   defp client() do
     middleware = [
       {Tesla.Middleware.BaseUrl, @base_url},
+      {Tesla.Middleware.Headers, [{"cache-control", "no-cache"}]},
       Tesla.Middleware.JSON
     ]
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,8 @@
 opts = [:skip]
 opts = opts ++ if System.get_env("UNIT") == "true", do: [:integration], else: []
 
+{:ok, _} = Inngest.Test.Application.start(:normal, [])
+
 ExUnit.start(exclude: opts)
 
 ExUnit.after_suite(fn _ ->


### PR DESCRIPTION
resolves #77 

The `Test.Application` is causing apps that included this library to crash on boot, because it's not compiled as part of the release.

Remove it so it no longer attempts to boot with `Inngest.Test.Application`.
`v0.2.0` is essentially useless at this point, so it should be yanked once this fix is out.

Update with some minor changes to make it comply to the latest spec.